### PR TITLE
Sets background-color on navbar for visual differentiation

### DIFF
--- a/src/components/navigation.rs
+++ b/src/components/navigation.rs
@@ -9,7 +9,7 @@ pub struct NavbarProps {
 #[function_component]
 pub fn Navbar(props: &NavbarProps) -> Html {
     html! {
-        <nav class="bp3-navbar bp3-fixed-top" aria-label="Main">
+        <nav id="navbar" class="bp3-navbar bp3-fixed-top" aria-label="Main">
         { for props.children.iter() }
         </nav>
     }

--- a/static/style.css
+++ b/static/style.css
@@ -10,6 +10,10 @@ main {
     display: flex;
 }
 
+#navbar {
+    background-color: #eee;
+}
+
 #files {
     width: 300px;
     overflow: scroll;


### PR DESCRIPTION
This sets a background color of `#eee` on the navbar to visually differentiate it from the rest of the site.

![Screenshot from 2023-03-10 23-30-40](https://user-images.githubusercontent.com/786420/224440418-576221b0-f926-4b55-a366-a63897509686.png)
