### PR TITLE
WIP default context folding

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -146,8 +146,8 @@ pub fn VersionResolver(props: &VersionResolverProps) -> Html {
     };
 
     // find krate version info
-    let left = props.info.versions.iter().find(|v| &v.num == left_str);
-    let right = props.info.versions.iter().find(|v| &v.num == right_str);
+    let left = props.info.version(left_str);
+    let right = props.info.version(right_str);
 
     match (left, right) {
         (Some(left), Some(right)) => html! {

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::data::{CrateResponse, CrateSource, VersionDiff};
+use crate::data::{CrateResponse, CrateSource, FileDiff, VersionDiff};
 use similar::ChangeTag;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -74,6 +74,16 @@ pub fn SourceView(props: &SourceViewProps) -> Html {
     }
 }
 
+/// Contains information about contiguous changes
+struct DiffGroupInfo {
+    /// The actual changes
+    group: Vec<(ChangeTag, bytes::Bytes)>,
+    /// What range of lines the group covers (used as a Yew list key)
+    range: std::ops::Range<usize>,
+    /// Whether the group contains an actual diff (and therefore shows some context)
+    in_context: bool,
+}
+
 #[derive(Properties, PartialEq, Clone)]
 pub struct DiffViewProps {
     pub path: String,
@@ -82,29 +92,141 @@ pub struct DiffViewProps {
 
 #[function_component]
 pub fn DiffView(props: &DiffViewProps) -> Html {
-    let changes = props.diff.files.get(&props.path);
+    let empty = FileDiff::default();
+    let file_diff = props.diff.files.get(&props.path).unwrap_or(&empty);
 
     // if this file does not exist, this will be none. so we use this trick to convert the none
     // case into an empty iterator, meaning that it will simply be rendered as an empty file.
-    let changes = changes.iter().flat_map(|changes| changes.iter());
+    let mut changes = file_diff.changes.iter();
+    let ranges = file_diff.context_ranges.iter();
+
+    // Group contiguous lines by whether they contain an actual diff +/- some context buffer.
+    let mut cursor = 0;
+    let mut stack: Vec<DiffGroupInfo> = vec![];
+    for next_range in ranges {
+        // out of context lines
+        if next_range.start != 0 {
+            stack.push(DiffGroupInfo {
+                group: changes
+                    .by_ref()
+                    .take(next_range.start - cursor)
+                    .cloned()
+                    .collect(),
+                range: cursor..next_range.start,
+                in_context: false,
+            });
+        }
+        // in context lines
+        stack.push(DiffGroupInfo {
+            group: changes
+                .by_ref()
+                .take(next_range.end - next_range.start)
+                .cloned()
+                .collect(),
+            range: next_range.clone(),
+            in_context: true,
+        });
+        cursor = next_range.end;
+    }
+    if changes.len() > 0 {
+        // Trailing unchanged lines at the end of a file
+        stack.push(DiffGroupInfo {
+            group: changes.by_ref().cloned().collect(),
+            range: cursor..file_diff.changes.len(),
+            in_context: false,
+        });
+    }
+
+    let mut overall_index = 0;
+    // Max of digits for a line number of this file
+    let padding = file_diff.changes.len().max(1).to_string().len();
+
     html! {
         <pre>
         {
-            changes
-                .map(|(tag, change)| {
+            stack.iter()
+                .map(|DiffGroupInfo {group, range, in_context}| {
+                    let res = html!{
+                        <DiffLineGroup
+                            key={format!("{:?}", range)}
+                            group={group.clone()}
+                            {in_context}
+                            group_start_index={overall_index}
+                            {padding}
+                        />
+                    };
+                    overall_index += group.len();
+                    res
+                })
+                .collect::<Html>()
+        }
+        </pre>
+    }
+}
+
+#[derive(Properties, PartialEq)]
+pub struct DiffLineGroupProps {
+    group: Vec<(ChangeTag, bytes::Bytes)>,
+    in_context: bool,
+    group_start_index: usize,
+    padding: usize,
+}
+
+#[function_component]
+pub fn DiffLineGroup(props: &DiffLineGroupProps) -> Html {
+    let folded = use_state(|| !props.in_context);
+    let padding = props.padding;
+    let onclick = {
+        let folded = folded.clone();
+        Callback::from(move |_| folded.set(!*folded))
+    };
+    let class = match (*folded, props.in_context) {
+        (true, true) => "folded in-context",
+        (true, false) => "folded out-of-context",
+        (false, true) => "in-context",
+        (false, false) => "out-of-context",
+    };
+    let group_start_index = props.group_start_index;
+    let end_index = group_start_index + props.group.len();
+
+    if *folded {
+        html! {
+            <button class={class} {onclick}>
+                {format!("Show lines {group_start_index} to {end_index}")}
+            </button>
+        }
+    } else {
+        html! {
+            <>
+            if !props.in_context {
+                <button class="folding-sticky" {onclick}>
+                    {format!("Fold lines {group_start_index} to {end_index}")}
+                </button>
+            }
+            <div class={class}>
+            {
+                props.group.iter().enumerate().map(|(index, (tag, change))| {
+                    let overall_index = group_start_index + index;
                     let (sign, color) = match tag {
                         ChangeTag::Delete => ("-", "red"),
                         ChangeTag::Insert => ("+", "green"),
                         ChangeTag::Equal => (" ", "default"),
                     };
-                    html!{
+                    let contents = String::from_utf8_lossy(&change[..]);
+                    html! {
                         <span style={format!("color: {color};")}>
-                            { format!("{sign} {}", String::from_utf8_lossy(&change[..])) }
+                            {
+                                format!(
+                                    "{overall_index:>padding$} {sign} {}",
+                                    contents
+                                )
+                            }
                         </span>
                     }
-                })
-                .collect::<Html>()
+                }).collect::<Html>()
+            }
+            </div>
+            </>
         }
-        </pre>
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -198,12 +198,11 @@ impl VersionDiff {
                     let value = change.value();
                     let value = [&left, &right]
                         .iter()
-                        .filter_map(|b| {
+                        .find_map(|b| {
                             b[..]
                                 .subslice_offset(value)
                                 .map(|index| b.slice(index..index + value.len()))
                         })
-                        .next()
                         .unwrap();
                     (change.tag(), value)
                 })

--- a/static/style.css
+++ b/static/style.css
@@ -1,5 +1,6 @@
 :root {
-    --top-nav-height: 50px;  /* keep in sync with `blueprint.css` */
+    --top-nav-height: 50px;
+    /* keep in sync with `blueprint.css` */
 }
 
 body {

--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,10 @@ main {
     background-color: #eee;
 }
 
+pre {
+    margin: 0;
+}
+
 #files {
     width: 300px;
     overflow: scroll;
@@ -26,4 +30,37 @@ main {
     padding-left: 8px;
     overflow: scroll;
     height: calc(100vh - var(--top-nav-height));
+}
+
+.out-of-context {
+    filter: opacity(0.7);
+}
+
+.out-of-context.folded {
+    border: 1px solid black;
+    padding: 1em;
+    text-align: center;
+    filter: none;
+    background-color: transparent;
+    width: 100%;
+    margin: 1em 0;
+    cursor: pointer;
+}
+
+.folded {
+    margin: 1em 0;
+}
+
+.folding-sticky {
+    cursor: pointer;
+    position: sticky;
+    top: 0;
+    border: 1px solid black;
+    padding: 1em;
+    text-align: center;
+    filter: none;
+    background-color: white;
+    width: 100%;
+    margin: 1em 0;
+    z-index: 100;
 }


### PR DESCRIPTION
**This is a draft, I have a working state after a long session and I haven't had time to really polish, clean up the code or make real commits. I wanted to give you a change to give your feedback for the general feel of it.**

Should address most of what #7 asked for. It's still not as good as I'd like it to be: we should be able to show fewer lines of context than the entire folded group, as well as provide the most relevant folded line (generally function or struct etc., which requires some language-level semantics, or just plain indentation lookup).

It's way too late to be up, sorry for rambling, I'll get some sleep.