### PR TITLE
Add support for diffing across crates

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,11 @@ pub enum Route {
     Search { krate: String },
     #[at("/:name/")]
     Crate { name: String },
+    #[at("/:src_name/:dst_name")]
+    Crates {
+        src_name: String,
+        dst_name: String,
+    },
     #[at("/:name/:old/:new")]
     SingleSourceDiff {
         name: String,
@@ -56,6 +61,14 @@ fn switch(route: Route) -> Html {
                 src_name={name.clone()}
                 dst_name={name}
                 old={VersionId::Named(VersionNamed::Previous)}
+                new={VersionId::Named(VersionNamed::Latest)}
+            />
+        },
+        Route::Crates { src_name, dst_name } => html! {
+            <Diff
+                src_name={src_name}
+                dst_name={dst_name}
+                old={VersionId::Named(VersionNamed::Latest)}
                 new={VersionId::Named(VersionNamed::Latest)}
             />
         },

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,15 +22,23 @@ pub enum Route {
     #[at("/:name/")]
     Crate { name: String },
     #[at("/:name/:old/:new")]
-    Diff {
+    SingleSourceDiff {
         name: String,
         old: VersionId,
         new: VersionId,
     },
     #[at("/:name/:old/:new/*path")]
-    File {
+    SingleSourceFile {
         name: String,
         old: VersionId,
+        new: VersionId,
+        path: String,
+    },
+    #[at("/:src_name/:old/:dst_name/:new/*path")]
+    File {
+        src_name: String,
+        old: VersionId,
+        dst_name: String,
         new: VersionId,
         path: String,
     },
@@ -45,21 +53,31 @@ fn switch(route: Route) -> Html {
         Route::About => html! { <About /> },
         Route::Crate { name } => html! {
             <Diff
-                {name}
+                src_name={name.clone()}
+                dst_name={name}
                 old={VersionId::Named(VersionNamed::Previous)}
                 new={VersionId::Named(VersionNamed::Latest)}
             />
         },
-        Route::Diff { name, old, new } => html! {
-            <Diff {name} {old} {new} />
+        Route::SingleSourceDiff { name, old, new } => html! {
+            <Diff src_name={name.clone()} dst_name={name} {old} {new} />
         },
-        Route::File {
+        Route::SingleSourceFile {
             name,
             old,
             new,
             path,
         } => html! {
-            <Diff {name} {old} {new} {path} />
+            <Diff src_name={name.clone()} dst_name={name} {old} {new} {path} />
+        },
+        Route::File {
+            src_name,
+            old,
+            dst_name,
+            new,
+            path,
+        } => html! {
+            <Diff {src_name} {dst_name} {old} {new} {path} />
         },
         Route::NotFound => html! { <NotFound /> },
         Route::Search { krate } => html! { <Search search={krate} /> },

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -11,7 +11,8 @@ use yew::prelude::*;
 
 #[derive(Properties, PartialEq, Clone)]
 pub struct SourceViewProps {
-    pub info: Arc<CrateResponse>,
+    pub src_info: Arc<CrateResponse>,
+    pub dst_info: Arc<CrateResponse>,
     pub old: Arc<CrateSource>,
     pub new: Arc<CrateSource>,
     pub path: String,
@@ -24,13 +25,15 @@ pub fn SourceView(props: &SourceViewProps) -> Html {
     });
     let navigator = use_navigator().unwrap();
     let onselect = {
-        let name = props.info.krate.id.clone();
+        let src_name = props.src_info.krate.id.clone();
+        let dst_name = props.dst_info.krate.id.clone();
         let old: VersionId = props.old.version.num.clone().into();
         let new: VersionId = props.new.version.num.clone().into();
         let navigator = navigator.clone();
         move |path: String| {
             navigator.push(&Route::File {
-                name: name.clone(),
+                src_name: src_name.clone(),
+                dst_name: dst_name.clone(),
                 old: old.clone(),
                 new: new.clone(),
                 path,
@@ -40,17 +43,19 @@ pub fn SourceView(props: &SourceViewProps) -> Html {
     html! {
         <>
         <ComplexNavbar
-            name={props.info.krate.id.clone()}
+            src_name={props.src_info.krate.id.clone()}
+            dst_name={props.dst_info.krate.id.clone()}
             old={props.old.version.num.clone()}
             new={props.new.version.num.clone()}
-            info={props.info.clone()}
+            src_info={props.src_info.clone()}
+            dst_info={props.dst_info.clone()}
             onchange={
-                let name = props.info.krate.id.clone();
                 let path = props.path.clone();
                 let navigator = navigator;
-                move |(old, new): (Version, Version)| {
+                move |((src_name, old), (dst_name, new)): ((String, Version), (String, Version))| {
                     navigator.push(&Route::File {
-                        name: name.clone(),
+                        src_name: src_name.clone(),
+                        dst_name: dst_name.clone(),
                         old: old.clone().into(),
                         new: new.clone().into(),
                         path: path.clone(),

--- a/src/components/navigation.rs
+++ b/src/components/navigation.rs
@@ -31,7 +31,7 @@ pub struct NavbarGroupProps {
 #[function_component]
 pub fn NavbarGroup(props: &NavbarGroupProps) -> Html {
     html! {
-        <div class="flex flex-row flex-nowrap gap-6">
+        <div class="flex flex-row flex-wrap sm:flex-nowrap gap-6">
             { for props.children.iter() }
         </div>
     }
@@ -218,56 +218,58 @@ pub fn ComplexNavbar(props: &ComplexNavbarProps) -> Html {
                 <NavbarHeading>
                     <Link<Route> to={Route::Home} classes="flex flex-row items-center"><YewIcon height={"1.5ex"} icon_id={IconId::LucideFileDiff} /><span>{ "diff.rs" }</span></Link<Route>></NavbarHeading>
                 <NavbarDivider />
-                <NavbarItem>
-                    <a href={format!("https://crates.io/crates/{}", src_name)} class="flex flex-row items-center">
-                        <YewIcon height={"1.5ex"} icon_id={IconId::LucideBox} />
-                    </a>
-                    { src_name.clone() }
-                </NavbarItem>
-                <NavbarItem>
-                    <Select
-                        values={src_versions.clone()}
-                        selected={Some(old.to_string().into()) as Option<IString>}
-                        onchange={
-                            let onchange = props.onchange.clone();
-                            let src_name = src_name.clone();
-                            let dst_name = dst_name.clone();
-                            let new = new.clone();
-                            move |old: IString| {
-                                let old: Version = old.parse().unwrap();
-                                onchange.emit(((src_name.clone(), old.clone()), (dst_name.clone(), new.clone())))
+                <NavbarGroup>
+                    <NavbarItem>
+                        <a href={format!("https://crates.io/crates/{}", src_name)} class="flex flex-row items-center">
+                            <YewIcon height={"1.5ex"} icon_id={IconId::LucideBox} />
+                        </a>
+                        { src_name.clone() }
+                    </NavbarItem>
+                    <NavbarItem>
+                        <Select
+                            values={src_versions.clone()}
+                            selected={Some(old.to_string().into()) as Option<IString>}
+                            onchange={
+                                let onchange = props.onchange.clone();
+                                let src_name = src_name.clone();
+                                let dst_name = dst_name.clone();
+                                let new = new.clone();
+                                move |old: IString| {
+                                    let old: Version = old.parse().unwrap();
+                                    onchange.emit(((src_name.clone(), old.clone()), (dst_name.clone(), new.clone())))
+                                }
                             }
-                        }
-                    />
-                </NavbarItem>
-                <NavbarItem>
-                    <span class="cursor-pointer hover:rotate-180 transition delay-150 duration-300 ease-in-out" onclick={switch}>
-                        <SwitchIcon />
-                    </span>
-                </NavbarItem>
-                <NavbarItem>
-                    <a href={format!("https://crates.io/crates/{}", dst_name)} class="flex flex-row items-center">
-                        <YewIcon height={"1.5ex"} icon_id={IconId::LucideBox} />
-                    </a>
-                    { dst_name.clone() }
-                </NavbarItem>
-                <NavbarItem>
-                    <Select
-                        values={dst_versions}
-                        selected={Some(new.to_string().into()) as Option<IString>}
-                        onchange={
-                            let onchange = props.onchange.clone();
-                            let src_name = src_name.clone();
-                            let dst_name = dst_name.clone();
-                            let old = old.clone();
-                            move |new: IString| {
-                                let new: Version = new.parse().unwrap();
-                                onchange.emit(((src_name.clone(), old.clone()), (dst_name.clone(), new.clone())))
+                        />
+                    </NavbarItem>
+                    <NavbarItem>
+                        <span class="cursor-pointer hover:rotate-180 transition delay-150 duration-300 ease-in-out" onclick={switch}>
+                            <SwitchIcon />
+                        </span>
+                    </NavbarItem>
+                    <NavbarItem>
+                        <a href={format!("https://crates.io/crates/{}", dst_name)} class="flex flex-row items-center">
+                            <YewIcon height={"1.5ex"} icon_id={IconId::LucideBox} />
+                        </a>
+                        { dst_name.clone() }
+                    </NavbarItem>
+                    <NavbarItem>
+                        <Select
+                            values={dst_versions}
+                            selected={Some(new.to_string().into()) as Option<IString>}
+                            onchange={
+                                let onchange = props.onchange.clone();
+                                let src_name = src_name.clone();
+                                let dst_name = dst_name.clone();
+                                let old = old.clone();
+                                move |new: IString| {
+                                    let new: Version = new.parse().unwrap();
+                                    onchange.emit(((src_name.clone(), old.clone()), (dst_name.clone(), new.clone())))
+                                }
                             }
-                        }
-                    />
-                </NavbarItem>
-                <NavbarDivider />
+                        />
+                    </NavbarItem>
+                    <NavbarDivider />
+                </NavbarGroup>
             </NavbarGroup>
             <NavbarGroup>
                 <Search />

--- a/src/data.rs
+++ b/src/data.rs
@@ -221,8 +221,8 @@ impl VersionDiff {
         let left = left.into();
         let right = right.into();
         info!(
-            "Computing diff for {} version {} and {}",
-            left.version.krate, left.version.num, right.version.num
+            "Computing diff for {} version {} and {} version {}",
+            left.version.krate, left.version.num, right.version.krate, right.version.num
         );
 
         let mut files = BTreeMap::new();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::data::*;
 use anyhow::Result;
 use serde_json::from_reader;
-use std::{fs::File, io::BufReader};
+use std::fs::File;
 
 fn parse_canned_response(name: &str) -> Result<CrateResponse> {
     let response = File::open(format!("data/{name}.json"))?;
@@ -43,19 +43,19 @@ fn test_crate_response_decode_log() {
 fn can_parse_crate_source_log_0_4_15() {
     let log = parse_canned_response("log").unwrap();
     let version = log.version("0.4.15".parse().unwrap()).unwrap();
-    let source = parse_canned_source(version).unwrap();
+    let _ = parse_canned_source(version).unwrap();
 }
 
 #[test]
 fn can_parse_crate_source_log_0_4_16() {
     let log = parse_canned_response("log").unwrap();
     let version = log.version("0.4.16".parse().unwrap()).unwrap();
-    let source = parse_canned_source(version).unwrap();
+    let _ = parse_canned_source(version).unwrap();
 }
 
 #[test]
 fn can_parse_crate_source_log_0_4_17() {
     let log = parse_canned_response("log").unwrap();
     let version = log.version("0.4.17".parse().unwrap()).unwrap();
-    let source = parse_canned_source(version).unwrap();
+    let _ = parse_canned_source(version).unwrap();
 }

--- a/src/views/diff.rs
+++ b/src/views/diff.rs
@@ -86,42 +86,37 @@ pub fn VersionResolver(props: &VersionResolverProps) -> Html {
     // find krate version info
     let old = props.src_info.version(props.old.clone());
     let new = props.dst_info.version(props.new.clone());
-    match (old, new) {
-        (Some(old), Some(new)) => html! {
-            <SourceFetcher
-                src_info={props.src_info.clone()}
-                dst_info={props.dst_info.clone()}
-                old={old.clone()}
-                new={new.clone()}
-                path={props.path.clone()}
-            />
-        },
-        (None, _) => html! {
-            <>
-                <SimpleNavbar />
+    let errors = match (old, new) {
+        (Some(old), Some(new)) => {
+            return html! {
+                <SourceFetcher
+                    src_info={props.src_info.clone()}
+                    dst_info={props.dst_info.clone()}
+                    old={old.clone()}
+                    new={new.clone()}
+                    path={props.path.clone()}
+                />
+            }
+        }
+        // get invalid versions from props
+        (None, Some(_)) => vec![(&props.src_info, &props.old)],
+        (Some(_), None) => vec![(&props.dst_info, &props.new)],
+        (None, None) => vec![(&props.src_info, &props.old), (&props.dst_info, &props.new)],
+    };
+    let errors = errors
+        .iter()
+        .map(|(info, version)| format!("Error: veresion {version} of {} not found", info.krate.id))
+        .collect::<Vec<_>>()
+        .join(" and ");
+    html! {
+        <>
+            <SimpleNavbar />
                 <Content>
                     <Center>
-                        <Error
-                            title={"Resolving version"}
-                            status={format!("Error: version {:?} not found", &old)}
-                        />
-                    </Center>
-                </Content>
-            </>
-        },
-        (_, None) => html! {
-            <>
-                <SimpleNavbar />
-                <Content>
-                    <Center>
-                        <Error
-                            title={"Resolving version"}
-                            status={format!("Error: version {} not found", &props.new)}
-                        />
-                    </Center>
-                </Content>
-            </>
-        },
+                    <Error title={"Resolving version"} status={errors} />
+                </Center>
+            </Content>
+        </>
     }
 }
 

--- a/src/views/diff.rs
+++ b/src/views/diff.rs
@@ -98,22 +98,28 @@ pub fn VersionResolver(props: &VersionResolverProps) -> Html {
         },
         (None, _) => html! {
             <>
-            <SimpleNavbar />
-            <Content>
-            <Center>
-            <Error title={"Resolving version"} status={format!("Error: version {old:?} not found")} />
-            </Center>
-            </Content>
+                <SimpleNavbar />
+                <Content>
+                    <Center>
+                        <Error
+                            title={"Resolving version"}
+                            status={format!("Error: version {:?} not found", &old)}
+                        />
+                    </Center>
+                </Content>
             </>
         },
         (_, None) => html! {
             <>
-            <SimpleNavbar />
-            <Content>
-            <Center>
-            <Error title={"Resolving version"} status={format!("Error: version {new:?} not found")} />
-            </Center>
-            </Content>
+                <SimpleNavbar />
+                <Content>
+                    <Center>
+                        <Error
+                            title={"Resolving version"}
+                            status={format!("Error: version {} not found", &props.new)}
+                        />
+                    </Center>
+                </Content>
             </>
         },
     }


### PR DESCRIPTION
This PR adds support for core functionality of diffing across crates only. It does not yet implement the UI part for choosing the destination crate.

Reviewing this PR commit by commit is recommended.

Part of #16. 