### PR TITLE
Basic support for browsing a specific version of a crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa",
@@ -1303,9 +1303,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/app.rs
+++ b/src/app.rs
@@ -19,6 +19,17 @@ pub enum Route {
     About,
     #[at("/search/:krate")]
     Search { krate: String },
+    #[at("/browse/:name/:version")]
+    Browse {
+        name: String,
+        version: VersionId,
+    },
+    #[at("/browse/:name/:version/*path")]
+    BrowseFile {
+        name: String,
+        version: VersionId,
+        path: String,
+    },
     #[at("/:name/")]
     Crate { name: String },
     #[at("/:src_name/:dst_name")]
@@ -56,6 +67,23 @@ fn switch(route: Route) -> Html {
     match route {
         Route::Home => html! { <Home /> },
         Route::About => html! { <About /> },
+        Route::Browse { name, version } => html! {
+            <Diff
+                src_name={name.clone()}
+                dst_name={name}
+                old={version.clone()}
+                new={version}
+            />
+        },
+        Route::BrowseFile { name, version, path } => html! {
+            <Diff
+                src_name={name.clone()}
+                dst_name={name}
+                old={version.clone()}
+                new={version}
+                {path}
+            />
+        },
         Route::Crate { name } => html! {
             <Diff
                 src_name={name.clone()}

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -103,6 +103,7 @@ pub struct DiffViewProps {
 pub fn DiffView(props: &DiffViewProps) -> Html {
     let empty = FileDiff::default();
     let file_diff = props.diff.files.get(&props.path).unwrap_or(&empty);
+    let is_identical_version = props.diff.left.version == props.diff.right.version;
 
     // if this file does not exist, this will be none. so we use this trick to convert the none
     // case into an empty iterator, meaning that it will simply be rendered as an empty file.
@@ -142,7 +143,9 @@ pub fn DiffView(props: &DiffViewProps) -> Html {
         stack.push(DiffGroupInfo {
             group: changes.by_ref().cloned().collect(),
             range: cursor..file_diff.changes.len(),
-            in_context: false,
+            // When comparing a version of the crate to itself, this group will
+            // always contain the full text of the file. Don't collapse it.
+            in_context: is_identical_version,
         });
     }
 


### PR DESCRIPTION
This adds a couple of new path endpoints which can be used to browse the
contents of a specific version of a crate. this is implemented under the hood
as a diff between a crate/version and itself.

When viewing one of these self-diffs, the folding logic is also modified to
default to not folding unchanged hunks, as needing to expand every file while
browsing is inconvenient.