### PR TITLE
Basic syntax highlighting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +67,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -178,6 +202,7 @@ dependencies = [
  "implicit-clone",
  "indexmap",
  "itertools",
+ "lazy_static",
  "log",
  "semver",
  "serde",
@@ -186,6 +211,7 @@ dependencies = [
  "similar",
  "strum",
  "subslice-offset",
+ "syntect",
  "tar",
  "tokio",
  "url",
@@ -229,6 +255,16 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -836,6 +872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +1094,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1158,15 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1245,6 +1325,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -1471,6 +1571,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1671,15 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
 dependencies = [
  "deranged",
  "itoa",
@@ -1303,9 +1303,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 sha2 = "0.10.8"
 similar = { version = "2.2.1", features = ["text", "bytes"] }
 strum = { version = "0.26.2", features = ["derive"] }
+syntect = { version = "5.0.0", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "regex-fancy"] }
 subslice-offset = "0.1.1"
 tar = "0.4.38"
 url = { version = "2.3.1", features = ["serde"] }
@@ -29,6 +30,7 @@ yew-hooks = "0.3.1"
 yew-router = "0.18.0"
 yew_icons = { version = "0.8.0", features = ["LucideBox", "LucideFileDiff"] }
 yewprint = { version = "0.5" }
+lazy_static = "1.5.0"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod app;
 mod cache;
 pub mod components;
 mod data;
+mod syntax;
 #[cfg(test)]
 mod tests;
 mod version;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,101 @@
+use similar::ChangeTag;
+use subslice_offset::SubsliceOffset;
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{Color, FontStyle, Style, Theme, ThemeSet},
+    parsing::{SyntaxReference, SyntaxSet},
+};
+
+lazy_static::lazy_static! {
+    /// The default syntect syntax set, used for parsing language definitions.
+    static ref SYNTAX_SET: SyntaxSet = SyntaxSet::load_defaults_newlines();
+    /// The default syntect theme set, currently only one theme is ever used.
+    static ref THEME_SET: ThemeSet = ThemeSet::load_defaults();
+    /// Theme definition from the default syntect theme set.
+    static ref THEME: &'static Theme = &THEME_SET.themes["InspiredGitHub"];
+}
+
+/// Get the `SyntaxReference` from `SYNTAX_SET` to use for syntax highlighting
+/// the given file.
+///
+/// It will be based first on the file's name, then the file's extension, and
+/// finally based on the first line of the file.
+pub fn infer_syntax_for_file(path: &str, first_line: Option<&str>) -> &'static SyntaxReference {
+    // Determine which syntax should be used for this file. It will be based
+    // first on the file's name, then the file's extension, then the first line.
+    let (_, file_name) = path.rsplit_once('/').unwrap_or(("", &path[..]));
+    let (_, extension) = file_name.rsplit_once('.').unwrap_or(("", file_name));
+    SYNTAX_SET
+        .find_syntax_by_extension(file_name)
+        .or_else(|| SYNTAX_SET.find_syntax_by_extension(extension))
+        .or_else(|| first_line.and_then(|line| SYNTAX_SET.find_syntax_by_first_line(line)))
+        .unwrap_or_else(|| SYNTAX_SET.find_syntax_plain_text())
+}
+
+/// Highlight a single line as a bytes slice, avoiding extra copies.
+fn highlight_bytes_line(
+    highlight_lines: &mut HighlightLines<'_>,
+    tag: ChangeTag,
+    bytes: &bytes::Bytes,
+) -> Option<Vec<(Style, bytes::Bytes)>> {
+    // Don't highlight removal lines, as it could confuse the parser.
+    if tag == ChangeTag::Delete {
+        return None;
+    }
+
+    let line = std::str::from_utf8(&bytes[..]).ok()?;
+    let styles = highlight_lines.highlight_line(&line, &SYNTAX_SET).ok()?;
+
+    // Map each chunk back to the bytes slice to avoid unnecessary copies.
+    Some(
+        styles
+            .into_iter()
+            .map(|(style, chunk)| {
+                let start = line[..].subslice_offset(chunk).unwrap();
+                (style, bytes.slice(start..start + chunk.len()))
+            })
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// Apply syntax highlighting to a list of changes using the listed syntax.
+pub fn highlight_changes(
+    syntax: &'static SyntaxReference,
+    changes: &[(ChangeTag, bytes::Bytes)],
+) -> Vec<(ChangeTag, Vec<(Style, bytes::Bytes)>)> {
+    let default_style = Style {
+        foreground: THEME.settings.foreground.unwrap_or(Color::BLACK),
+        background: THEME.settings.background.unwrap_or(Color::WHITE),
+        font_style: FontStyle::empty(),
+    };
+
+    let mut highlight_lines = HighlightLines::new(syntax, &THEME);
+    changes
+        .iter()
+        .map(|(tag, bytes)| {
+            let styled = highlight_bytes_line(&mut highlight_lines, *tag, bytes)
+                .unwrap_or_else(|| vec![(default_style, bytes.clone())]);
+            (*tag, styled)
+        })
+        .collect()
+}
+
+/// Convert the given syntect style to inline `style` attribute formatting.
+///
+/// Does not apply background colors.
+pub fn syntect_style_to_css(style: &Style) -> String {
+    let mut css = format!(
+        "color:#{:02x}{:02x}{:02x};",
+        style.foreground.r, style.foreground.g, style.foreground.b
+    );
+    if style.font_style.contains(FontStyle::UNDERLINE) {
+        css.push_str("text-decoration:underline;");
+    }
+    if style.font_style.contains(FontStyle::BOLD) {
+        css.push_str("font-weight:bold;");
+    }
+    if style.font_style.contains(FontStyle::BOLD) {
+        css.push_str("font-style:italic;");
+    }
+    css
+}


### PR DESCRIPTION
This patch adds basic syntax highlighting support using the `syntect` crate and the default themes & languages supported by that crate.

This unfortunately does increase the size of the wasm blob, and can slow down display of large documents (especially when building without optimizations). This appears to mostly be due to the inclusion of the regex crate and a blob containing language definition regexes.

It may make sense to use more tailored asset sets with only the used theme & languages in the future to keep down on binary size.

![code formatting example from the `tokio` crate](https://github.com/user-attachments/assets/983e05a5-6207-4d23-b21b-b37cfe206c2a)
