### PR TITLE
Hide files and subtrees without changes

### DIFF
--- a/src/components/file_tree.rs
+++ b/src/components/file_tree.rs
@@ -155,14 +155,19 @@ fn SubTree(props: &SubTreeProps) -> Html {
     html! {
         <div class="file-subtree">
         {
-            entries.iter().map(|(key, entry)| html! {
-                <FileEntry
-                    key={key.to_string()}
-                    context={props.context.clone()}
-                    entry={entry.clone()}
-                    prefix={prefix.clone()}
-                    active={props.active.clone()}
-                />
+            entries.iter().filter_map(|(key, entry)| {
+                if entry.changes.has_changes() {
+                    Some(html! {
+                    <FileEntry
+                        key={key.to_string()}
+                        context={props.context.clone()}
+                        entry={entry.clone()}
+                        prefix={prefix.clone()}
+                        active={props.active.clone()}
+                    />})
+                } else {
+                    None
+                }
             }).collect::<Html>()
         }
         </div>
@@ -189,14 +194,19 @@ pub fn FileTree(props: &FileTreeProps) -> Html {
     html! {
         <div class="file-tree">
         {
-            entries.into_iter().map(|(key, entry)| html! {
-                <FileEntry
-                    {key}
-                    {entry}
-                    prefix={prefix.clone()}
-                    active={active.clone()}
-                    context={context.clone()}
-                />
+            entries.into_iter().filter_map(|(key, entry)| {
+                if entry.changes.has_changes() {
+                    Some(html! {
+                    <FileEntry
+                        {key}
+                        {entry}
+                        prefix={prefix.clone()}
+                        active={active.clone()}
+                        context={context.clone()}
+                    />})
+                } else {
+                    None
+                }
             }).collect::<Html>()
         }
         </div>

--- a/src/data.rs
+++ b/src/data.rs
@@ -399,6 +399,12 @@ pub struct Changes {
     pub removed: u64,
 }
 
+impl Changes {
+    pub(crate) fn has_changes(&self) -> bool {
+        self.added != 0 || self.removed != 0
+    }
+}
+
 impl std::ops::Add for Changes {
     type Output = Self;
     fn add(mut self, rhs: Self) -> Self {


### PR DESCRIPTION
Fixes https://github.com/xfbs/diff.rs/issues/44

Just had my first look at the project and put together this quick PR. Checks whether or not an entry has changes (added a helper function for this) and skips it when creating the tree if necessary. Please let me know if there is a more idiomatic way to tackle this.

Best regards!