### PR TITLE
ignore files created by IntelliJ IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 # trunk build artifacts
 /dist
+
+.idea/


### PR DESCRIPTION
Ignoring files that are created by IDEs made by IntelliJ (such as RustRover).