### PR TITLE
feat: Expand and collapse directories in file tree

### DIFF
--- a/src/components/file_tree.rs
+++ b/src/components/file_tree.rs
@@ -83,7 +83,7 @@ struct FileEntryProps {
 
 #[derive(Debug, Properties, Clone, Copy, PartialEq)]
 struct ExpandIconProps {
-    pub is_expanded: bool
+    pub is_expanded: bool,
 }
 
 #[function_component]

--- a/src/components/file_tree.rs
+++ b/src/components/file_tree.rs
@@ -108,14 +108,8 @@ fn FileIcon() -> Html {
 
 #[function_component]
 fn ExpandIcon(props: &ExpandIconProps) -> Html {
-    let rotate_class = if props.is_expanded {
-        "rotate-90"
-    } else {
-        "rotate-0"
-    };
-
     html! {
-        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class={rotate_class}>
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class={(props.is_expanded).then_some("rotate-90")}>
             <path fill-rule="evenodd" clip-rule="evenodd" d="M8.79289 6.29289C9.18342 5.90237 9.81658 5.90237 10.2071 6.29289L15.2071 11.2929C15.5976 11.6834 15.5976 12.3166 15.2071 12.7071L10.2071 17.7071C9.81658 18.0976 9.18342 18.0976 8.79289 17.7071C8.40237 17.3166 8.40237 16.6834 8.79289 16.2929L13.0858 12L8.79289 7.70711C8.40237 7.31658 8.40237 6.68342 8.79289 6.29289Z" />
         </svg>
     }


### PR DESCRIPTION
This patch allows the user to expand directories in the file tree by clicking the expand icon (">"). When expanded, the directory's contents will be listed below the entry for the directory itself. This subtree can be collapsed (hidden) by clicking the icon again.

Somewhat address #42... It might also be a good idea to not change the current diff if a directory is clicked?