### PR TITLE
fix: Start line numbers at 0

### DIFF
--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -165,11 +165,9 @@ pub fn DiffLineGroup(props: &DiffLineGroupProps) -> Html {
                     };
                     html! {
                         <div style={format!("background-color:{bg_color}")}>
-                            <span class="select-none">
                             {
                                 format!("{overall_index:>padding$} {sign} ")
                             }
-                            </span>
                             {
                                 change.iter().map(|(style, text)| {
                                     let style = syntect_style_to_css(style);

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -137,8 +137,8 @@ pub fn DiffLineGroup(props: &DiffLineGroupProps) -> Html {
         (false, true) => "in-context",
         (false, false) => "out-of-context",
     };
-    let group_start_index = props.group_start_index;
-    let end_index = group_start_index + props.group.len();
+    let group_start_index = props.group_start_index + 1;
+    let end_index = group_start_index + props.group.len() - 1;
 
     if *folded {
         html! {

--- a/src/components/diff_view.rs
+++ b/src/components/diff_view.rs
@@ -165,9 +165,11 @@ pub fn DiffLineGroup(props: &DiffLineGroupProps) -> Html {
                     };
                     html! {
                         <div style={format!("background-color:{bg_color}")}>
+                            <span class="select-none">
                             {
                                 format!("{overall_index:>padding$} {sign} ")
                             }
+                            </span>
                             {
                                 change.iter().map(|(style, text)| {
                                     let style = syntect_style_to_css(style);


### PR DESCRIPTION
Line numbers now properly start at 0 in the diff view. 

This patch also fixes an off-by-one error in the "Show/Fold lines..." blocks, where the end line number was too high by 1.

Partially addresses some of the issues noted in #52.
![image](https://github.com/user-attachments/assets/9fd0a6d7-1789-4235-af0d-879fca1f24d3)
