### PR TITLE
Upgrades Trunk to 0.21.1, along with tools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
 
 variables:
   RUST_VERSION: "1.81"
-  TRUNK_VERSION: "0.20.3"
+  TRUNK_VERSION: "0.21.1"
 
 # Run unit tests
 test:

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,7 @@
+
+# the versions are specified here to get reproducible builds, make sure to
+# bump the versions of these tools occasionally.
+[tools]
+wasm_opt = "version_119"
+wasm_bindgen = "0.2.95"
+tailwindcss = "3.4.14"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+# there is currently an issue when building diff.rs with rust 1.82. can bump
+# this once this is resolved: 
+channel = "1.81"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This updates Trunk to 0.21.1, and upgrades some of the tools used (`wasm-opt`, `wasm-bindgen`, `tailwindcss`).