### PR TITLE
expand when anchor for folded group called & scroll after init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ yew-hooks = "0.3.1"
 yew-router = "0.18.0"
 yew_icons = { version = "0.8.0", features = ["LucideBox", "LucideFileDiff"] }
 yewprint = { version = "0.5" }
+gloo-events = {version = "0.2"}
+
 
 # enable LTO and use a single codegen-unit to get smaller and more efficient code.
 [profile.release]


### PR DESCRIPTION
tried to do the second point of #76 

Had somewhat trouble when calling anchor on not rendered page (also w/ master). Its a bit hard to test on diff.rs bc for some reason all calls `url#...` are seem to be rerouted to `url/#...` or sth like that idk[^1].

Beside this i am a bit confused: the snipped i used to scroll to the anchored element fails to find the object in question when called after initial rendering, so i used the workaround of changing the state in this case. Maybe you could give me some insight here?

[^1]: or maybe doing sth wrong idk - then this might be a bugreport

